### PR TITLE
Upgrade @cloudentity/auth to version 1.0.0 beta.3

### DIFF
--- a/01-SPA_Login/package-lock.json
+++ b/01-SPA_Login/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@cloudentity/auth": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@cloudentity/auth/-/auth-1.0.0-beta.0.tgz",
-      "integrity": "sha512-0uhYv52x2/WpFoQqguRmfdKfJek7/cuyKDQ5/00qqbd1lZ+pZpVBS4mXxQZctKlmP2iT4BrYKKyr2FVRDVlCLQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@cloudentity/auth/-/auth-1.0.0-beta.3.tgz",
+      "integrity": "sha512-iBsfbg4uCN39VyKO7B2OzSUe/xTPJoehSMkdEpAQCDcxg8aiBBWs0+Gnf22IEcoXFJq/PRkKWF4D/+Qx15VL6g==",
       "requires": {
         "babel-runtime": "6.26.0"
       }

--- a/01-SPA_Login/package.json
+++ b/01-SPA_Login/package.json
@@ -9,7 +9,7 @@
   "author": "Cloudentity",
   "license": "SEE LICENSE IN EULA.txt",
   "dependencies": {
-    "@cloudentity/auth": "1.0.0-beta.0",
+    "@cloudentity/auth": "1.0.0-beta.3",
     "bootstrap": "4.5.2",
     "fast-text-encoding": "1.0.3",
     "promise-polyfill": "8.1.3",

--- a/02-SPA_User_Profile/package-lock.json
+++ b/02-SPA_User_Profile/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@cloudentity/auth": {
-      "version": "1.0.0-beta.0",
-      "resolved": "https://registry.npmjs.org/@cloudentity/auth/-/auth-1.0.0-beta.0.tgz",
-      "integrity": "sha512-0uhYv52x2/WpFoQqguRmfdKfJek7/cuyKDQ5/00qqbd1lZ+pZpVBS4mXxQZctKlmP2iT4BrYKKyr2FVRDVlCLQ==",
+      "version": "1.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@cloudentity/auth/-/auth-1.0.0-beta.3.tgz",
+      "integrity": "sha512-iBsfbg4uCN39VyKO7B2OzSUe/xTPJoehSMkdEpAQCDcxg8aiBBWs0+Gnf22IEcoXFJq/PRkKWF4D/+Qx15VL6g==",
       "requires": {
         "babel-runtime": "6.26.0"
       }

--- a/02-SPA_User_Profile/package.json
+++ b/02-SPA_User_Profile/package.json
@@ -9,7 +9,7 @@
   "author": "Cloudentity",
   "license": "SEE LICENSE IN EULA.txt",
   "dependencies": {
-    "@cloudentity/auth": "1.0.0-beta.0",
+    "@cloudentity/auth": "1.0.0-beta.3",
     "bootstrap": "4.5.2",
     "fast-text-encoding": "1.0.3",
     "promise-polyfill": "8.1.3",

--- a/README.md
+++ b/README.md
@@ -40,3 +40,8 @@ To play with each example project:
     ```
     http://localhost:8000 
     ```
+
+### For further info
+
+Check out the NPM page for the `@cloudentity/auth` library for info on all available features:
+https://www.npmjs.com/package/@cloudentity/auth


### PR DESCRIPTION
Version bump contains under-the-hood improvements for certain edge cases, but does not affect existing functionality of samples.

Link to docs on public NPM info page for `@cloudentity/auth` library added to README.

Re-tested in IE11 to ensure continued compatibility with library updates.